### PR TITLE
Improve local development with trino cluster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ start:
 migrate:
 	docker-compose up -d postgres
 	docker-compose run --build proxy /app/node_modules/.bin/knex migrate:latest
+	docker-compose run --build proxy /app/node_modules/.bin/knex seed:run
 
 # Cleanup all docker containers
 clean:

--- a/README.md
+++ b/README.md
@@ -9,8 +9,16 @@ This project requires Node16+, Docker, and docker-compose. Please ensure you hav
 Build and run docker containers:
 
 ```sh
-make migrate    # create postgres db and run migrations
+make clean      # remove all existing containers
+make migrate    # create postgres db, run migrations, and seed data
 make start      # run trino-proxy
+```
+
+In another shell, you can use the Trino CLI to execute commands against the cluster (via trino-proxy):
+
+```sh
+brew install trino
+trino --server http://localhost:8080 --user admin
 ```
 
 ## Contributing

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,18 +3,20 @@ version: "3.7"
 services:
   proxy:
     build: .
-    container_name: trino-proxy
     restart: always
     volumes:
+      - ./migrations:/app/migrations
+      - ./seeds:/app/seeds
       - ./src:/app/src
     ports:
       - 8080:8080
     depends_on:
       - postgres
     environment:
+      - DB_URL=postgres://trino_proxy:trino_proxy@postgres/trino_proxy
+      - HTTP_ENABLED=true
       - LOG_LEVEL=debug
       - NODE_ENV=production
-      - DB_URL=postgres://trino_proxy:trino_proxy@postgres/trino_proxy
 
   postgres:
     image: postgres:13
@@ -23,3 +25,9 @@ services:
       POSTGRES_USER: trino_proxy
       POSTGRES_PASSWORD: trino_proxy
       POSTGRES_DB: trino_proxy
+
+  trino:
+    image: trinodb/trino
+    restart: always
+    ports:
+      - 8081:8080

--- a/seeds/initialize.js
+++ b/seeds/initialize.js
@@ -1,0 +1,28 @@
+const uuidv4 = require("uuid").v4;
+const now = new Date();
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.seed = async function (knex) {
+  await knex("user").del();
+  await knex("user").insert({
+    id: uuidv4(),
+    name: "admin",
+    password: "{}", // no password
+    parsers: null,
+    updated_at: now,
+    created_at: now,
+  });
+
+  await knex("cluster").del();
+  await knex("cluster").insert({
+    id: uuidv4(),
+    name: "trino",
+    url: "http://trino:8080",
+    status: "enabled",
+    updated_at: now,
+    created_at: now,
+  });
+};


### PR DESCRIPTION
This PR improves local development by adding a trino cluster (single coordinator + worker) to the docker-compose file as well as seeds the local database with the cluster and admin user. This allows users to test changes easier by using the Trino CLI locally.