### PR TITLE
Uppercase stored statuses to match Trino states

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -12,6 +12,7 @@ services:
       - 8080:8080
     depends_on:
       - postgres
+      - trino
     environment:
       - DB_URL=postgres://trino_proxy:trino_proxy@postgres/trino_proxy
       - HTTP_ENABLED=true

--- a/migrations/20230117224727_update_statuses.js
+++ b/migrations/20230117224727_update_statuses.js
@@ -1,0 +1,25 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function (knex) {
+  await knex.transaction(async (trx) => {
+    await knex.raw("UPDATE query SET status = UPPER(status)").transacting(trx);
+    await knex
+      .raw("UPDATE cluster SET status = UPPER(status)")
+      .transacting(trx);
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async function (knex) {
+  await knex.transaction(async (trx) => {
+    await knex.raw("UPDATE query SET status = LOWER(status)").transacting(trx);
+    await knex
+      .raw("UPDATE cluster SET status = LOWER(status)")
+      .transacting(trx);
+  });
+};

--- a/src/babysitter.js
+++ b/src/babysitter.js
@@ -10,9 +10,15 @@ const BABYSITTER_DELAY = process.env.BABYSITTER_DELAY
   ? parseInt(process.env.BABYSITTER_DELAY)
   : 3000;
 
+const COMPLETED_STATUSES = [
+  QUERY_STATUS.LOST,
+  QUERY_STATUS.FINISHED,
+  QUERY_STATUS.FAILED,
+].join(",");
+
 async function babysitQueries() {
   const currentQueries = await knex.raw(
-    `select * from query where not status ilike any('{lost,finished,failed}')`
+    `select * from query where not status ilike any('{${COMPLETED_STATUSES}}')`
   );
 
   await BPromise.map(

--- a/src/lib/cluster.js
+++ b/src/lib/cluster.js
@@ -5,12 +5,8 @@ const axios = require("axios").default;
 const { knex } = require("./knex");
 
 const CLUSTER_STATUS = {
-  ENABLED: "enabled",
-  DISABLED: "disabled",
-};
-
-const stateMap = {
-  FINISHED: "finished",
+  ENABLED: "ENABLED",
+  DISABLED: "DISABLED",
 };
 
 async function getClusterById(clusterId) {
@@ -69,7 +65,7 @@ async function getQueryStatus(clusterId, queryId) {
   }
 
   return {
-    state: stateMap[result.data.state] || result.data.state,
+    state: result.data.state,
     cumulativeUserMemoryMB: _.get(
       result.data,
       "queryStats.cumulativeUserMemory"

--- a/src/lib/query.js
+++ b/src/lib/query.js
@@ -2,11 +2,16 @@ const { knex } = require("./knex");
 const cache = require("./memcache");
 
 const QUERY_STATUS = {
-  AWAITING_SCHEDULING: "awaiting_scheduling",
-  FAILED: "failed",
-  FINISHED: "finished",
-  LOST: "lost",
-  QUEUED: "queued",
+  AWAITING_SCHEDULING: "AWAITING_SCHEDULING",
+  BLOCKED: "BLOCKED",
+  FAILED: "FAILED",
+  FINISHED: "FINISHED",
+  FINISHING: "FINISHING",
+  LOST: "LOST",
+  PLANNING: "PLANNING",
+  QUEUED: "QUEUED",
+  RUNNING: "RUNNING",
+  STARTING: "STARTING",
 };
 
 async function getQueryById(newQueryId) {

--- a/src/routes/trino.js
+++ b/src/routes/trino.js
@@ -90,7 +90,7 @@ router.post("/v1/statement", async (req, res) => {
           newQueryId +
           "/mock_next_uri/1",
         stats: {
-          state: "QUEUED",
+          state: QUERY_STATUS.QUEUED,
         },
       },
       newQueryId,
@@ -127,7 +127,7 @@ router.get("/v1/statement/queued/:queryId/:keyId/:num", async (req, res) => {
             query.id +
             "/mock_next_uri/1",
           stats: {
-            state: "QUEUED",
+            state: QUERY_STATUS.QUEUED,
           },
         },
         query.id,
@@ -148,7 +148,7 @@ router.get("/v1/statement/queued/:queryId/:keyId/:num", async (req, res) => {
             "/" +
             query.next_uri,
           stats: {
-            state: "QUEUED",
+            state: QUERY_STATUS.QUEUED,
           },
         },
         query.id,


### PR DESCRIPTION
This PR syncs query status with Trino docs - Trino uses capitalized statuses whereas the proxy uses lowercased status. A new Postgres migration is added to change historical queries. Cluster statuses are also uppercased for consistency.