### PR TITLE
Add support for query source and tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,16 @@ brew install trino
 trino --server http://localhost:8080 --user admin
 ```
 
+Creating a new user via API:
+
+```sh
+curl \
+    --request POST \
+    --user "admin" \
+    --json '{ "username": "test", "password": "", "tags": ["test"] }' \
+    http://localhost:8080/v1/user
+```
+
 ## Contributing
 
 Format and lint the source code:

--- a/migrations/20230118121807_add_query_source_tags.js
+++ b/migrations/20230118121807_add_query_source_tags.js
@@ -1,0 +1,29 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function (knex) {
+  return knex.schema
+    .alterTable("user", (table) => {
+      table.specificType("tags", "varchar[]");
+    })
+    .alterTable("query", (table) => {
+      table.string("source");
+      table.specificType("tags", "varchar[]");
+    });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function (knex) {
+  return knex.schema
+    .alterTable("user", (table) => {
+      table.dropColumn("tags");
+    })
+    .alterTable("query", (table) => {
+      table.dropColumn("source");
+      table.dropColumn("tags");
+    });
+};

--- a/seeds/initialize.js
+++ b/seeds/initialize.js
@@ -12,6 +12,7 @@ exports.seed = async function (knex) {
     name: "admin",
     password: "{}", // no password
     parsers: null,
+    tags: "{admin}",
     updated_at: now,
     created_at: now,
   });

--- a/src/middlewares/authentication.js
+++ b/src/middlewares/authentication.js
@@ -60,6 +60,7 @@ module.exports = async function (req, res, next) {
           id: user.id,
           username: username,
           parsers: user.parsers,
+          tags: user.tags || [],
         };
       }
     }

--- a/src/routes/trino.js
+++ b/src/routes/trino.js
@@ -66,6 +66,7 @@ router.post("/v1/statement", async (req, res) => {
 
   const newQueryId = uuidv4();
   const times = new Date();
+  const querySource = req.headers["x-trino-source"] || null;
 
   await knex("query").insert({
     id: newQueryId,
@@ -73,7 +74,9 @@ router.post("/v1/statement", async (req, res) => {
     body: req.body,
     trace_id: trinoTraceToken,
     assumed_user: assumedUser,
-    user: req.user ? req.user.id : null,
+    source: querySource,
+    tags: req.user.tags || [],
+    user: req.user.id || null,
     created_at: times,
     updated_at: times,
   });


### PR DESCRIPTION
* Adds query source to the query table so that this information can be passed through to the Trino cluster for troubleshooting queries.
* Adds query client tags to both the user and query tables. Client tags can be set on the user level and passed through with statements to Trino for troubleshooting queries. The trino-proxy tag is also added. A future change will allow client tags sent to trino-proxy to be passed through as well.


![Screenshot 2023-01-18 at 9 03 07 AM](https://user-images.githubusercontent.com/9093075/213191530-a0fd7207-10e1-4c4f-a946-5f3ec99e05cf.png)
