### PR TITLE
Check cluster health before scheduling queries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ format:
 
 # Start docker containers
 start:
-	docker-compose up --build
+	docker-compose up --build --attach proxy
 
 # Run database migrations against db
 migrate:

--- a/seeds/initialize.js
+++ b/seeds/initialize.js
@@ -1,4 +1,6 @@
 const uuidv4 = require("uuid").v4;
+const { CLUSTER_STATUS } = require("../src/lib/cluster");
+
 const now = new Date();
 
 /**
@@ -22,7 +24,7 @@ exports.seed = async function (knex) {
     id: uuidv4(),
     name: "trino",
     url: "http://trino:8080",
-    status: "enabled",
+    status: CLUSTER_STATUS.ENABLED,
     updated_at: now,
     created_at: now,
   });

--- a/src/babysitter.js
+++ b/src/babysitter.js
@@ -61,5 +61,6 @@ async function runBabysitAndReschedule() {
 
 // Kick off initial babysit task
 if (!BABYSITTER_DISABLED) {
+  logger.info(`Scheduling query babysitter to run every ${BABYSITTER_DELAY}ms`);
   runBabysitAndReschedule();
 }

--- a/src/lib/helpers.js
+++ b/src/lib/helpers.js
@@ -39,7 +39,7 @@ async function replaceAuthorizationHeader(req) {
   }
 
   if (headerUser) {
-    logger.debug("Replacing authorization header", { headerUser });
+    logger.silly("Replacing authorization header", { headerUser });
     req.headers.authorization =
       "Basic " + Buffer.from(headerUser).toString("base64");
   }

--- a/src/lib/stats.js
+++ b/src/lib/stats.js
@@ -9,6 +9,6 @@ const {
 module.exports = new StatsD({
   host: STATSD_HOST,
   port: STATSD_PORT,
-  prefix: STATSD_PREFIX,
+  prefix: STATSD_PREFIX + ".",
   globalTags: { env: process.env.NODE_ENV },
 });

--- a/src/lib/trino.js
+++ b/src/lib/trino.js
@@ -57,33 +57,40 @@ async function scheduleQueries() {
       const cluster = availableClusters[currentClusterId];
       currentClusterId = (currentClusterId + 1) % availableClusters.length;
 
+      const user = query.assumed_user || query.user;
+      const source = query.source || "trino-proxy";
+
       // Pass through any user tags to Trino for resource group management
       const userTags = Array.isArray(query.tags) ? query.tags : [];
       // Add custom tag so that queries can always be traced back to trino-proxy
       const clientTags = userTags.concat("trino-proxy");
 
-      logger.debug("Submitting query", {
-        id: query.id,
-        url: cluster.url,
-        user: query.assumed_user,
-        source: query.source,
-        clientTags,
-        clusterId: cluster.id,
-      });
-
       const response = await axios({
         url: cluster.url + "/v1/statement",
         method: "post",
         headers: {
-          "X-Trino-User": query.assumed_user,
-          "X-Trino-Source": query.source || "trino-proxy",
+          "X-Trino-User": user,
+          "X-Trino-Source": source,
           "X-Trino-Client-Tags": clientTags.join(","),
         },
         data: query.body,
       });
 
-      logger.debug("Trino cluster response", { data: response.data });
-      stats.increment("query_queued", 1);
+      logger.debug("Submitted query to Trino cluster", {
+        user,
+        source,
+        clientTags,
+        cluster: cluster.name,
+        data: response.data,
+      });
+
+      stats.increment("query_queued", [
+        `cluster:${cluster.name}`,
+        `user:${user}`,
+        `source:${source}`,
+        ...clientTags,
+      ]);
+
       const nextURI = response.data.nextUri.split(response.data.id + "/")[1];
       await knex("query").where({ id: query.id }).update({
         cluster_query_id: response.data.id,

--- a/src/lib/trino.js
+++ b/src/lib/trino.js
@@ -19,7 +19,7 @@ async function scheduleQueries() {
       status: QUERY_STATUS.AWAITING_SCHEDULING,
     });
 
-    stats.gauge("queries_waiting_scheduling", queriesToSchedule.length);
+    stats.increment("queries_waiting_scheduling", queriesToSchedule.length);
     if (queriesToSchedule.length === 0) return;
 
     const enabledClusters = await knex("cluster").where({
@@ -39,7 +39,7 @@ async function scheduleQueries() {
       }
     );
 
-    stats.gauge("available_clusters", availableClusters.length);
+    stats.increment("available_clusters", availableClusters.length);
     if (availableClusters.length === 0) {
       logger.error("No healthy clusters available", {
         enabled: enabledClusters.length,
@@ -76,7 +76,7 @@ async function scheduleQueries() {
         data: query.body,
       });
 
-      logger.debug("Submitted query to Trino cluster", {
+      logger.info("Submitted query to Trino cluster", {
         user,
         source,
         clientTags,

--- a/src/lib/trino.js
+++ b/src/lib/trino.js
@@ -19,7 +19,7 @@ async function scheduleQueries() {
       status: QUERY_STATUS.AWAITING_SCHEDULING,
     });
 
-    stats.increment("queries_waiting_scheduling", queriesToSchedule.length);
+    stats.gauge("queries_waiting_scheduling", queriesToSchedule.length);
     if (queriesToSchedule.length === 0) return;
 
     const enabledClusters = await knex("cluster").where({
@@ -39,7 +39,7 @@ async function scheduleQueries() {
       }
     );
 
-    stats.increment("available_clusters", availableClusters.length);
+    stats.gauge("available_clusters", availableClusters.length);
     if (availableClusters.length === 0) {
       logger.error("No healthy clusters available", {
         enabled: enabledClusters.length,
@@ -83,6 +83,7 @@ async function scheduleQueries() {
       });
 
       logger.debug("Trino cluster response", { data: response.data });
+      stats.increment("query_queued", 1);
       const nextURI = response.data.nextUri.split(response.data.id + "/")[1];
       await knex("query").where({ id: query.id }).update({
         cluster_query_id: response.data.id,

--- a/src/middlewares/authentication.js
+++ b/src/middlewares/authentication.js
@@ -19,7 +19,7 @@ module.exports = async function (req, res, next) {
 
         username = foundHeader[0];
         password = foundHeader[1];
-        logger.debug("Found Auth header", { username });
+        logger.silly("Found Auth header", { username });
 
         // only accept the first Authorization header
         break;
@@ -27,7 +27,7 @@ module.exports = async function (req, res, next) {
     }
   } else if (req.headers["x-trino-user"]) {
     username = req.headers["x-trino-user"];
-    logger.debug("Found Trino User header", { username });
+    logger.silly("Found Trino User header", { username });
   }
 
   if (username) {

--- a/src/server.js
+++ b/src/server.js
@@ -59,11 +59,13 @@ if (HTTPS_ENABLED) {
   };
   const httpsServer = https.createServer(credentials, app);
   httpsServer.listen(HTTPS_LISTEN_PORT);
+  logger.info(`HTTPS server listen on port ${HTTPS_LISTEN_PORT}`);
 }
 
 if (!HTTPS_ENABLED || HTTP_ENABLED) {
   const httpServer = http.createServer(app);
   httpServer.listen(HTTP_LISTEN_PORT);
+  logger.info(`HTTP server listen on port ${HTTP_LISTEN_PORT}`);
 }
 
 // Require babysitter last once server is setup and running successfully


### PR DESCRIPTION
This PR adds functionality to check that a Trino cluster is healthy before scheduling queries to it. Scheduling a query when the server is initializing will result in a failed query. The Trino docs say that the server should return a 500/503 when this is happening, but I couldn't replicate that functionality. It appears that the http server starts accepting queries (and returning 200s) before they're able to be queued.

In the case that there are no enabled or healthy clusters, a DD metric with the query backlog is incremented.

In addition, the level of some logs was reduced to prevent noisy messages while developing and in QA environments.