### PR TITLE
Implement row-level locks for horizontal scaling

### DIFF
--- a/src/lib/trino.js
+++ b/src/lib/trino.js
@@ -9,18 +9,22 @@ const { QUERY_STATUS } = require("../lib/query");
 
 let schedulerRunning = false;
 const SCHEDULER_DELAY_MS = 1000 * 15;
+const MAX_QUERIES_QUEUED = 5;
 
 async function scheduleQueries() {
   if (schedulerRunning) return;
   const startTime = new Date();
 
   try {
-    const queriesToSchedule = await knex("query").where({
-      status: QUERY_STATUS.AWAITING_SCHEDULING,
-    });
+    const queriesToSchedule = await knex("query")
+      .where({ status: QUERY_STATUS.AWAITING_SCHEDULING })
+      .count("*");
 
-    stats.increment("queries_waiting_scheduling", queriesToSchedule.length);
-    if (queriesToSchedule.length === 0) return;
+    // Increment number of pending queries for monitoring
+    // If there are none, just early exit to prevent the extra db calls
+    const numberQueriesPending = parseInt(queriesToSchedule[0].count) || 0;
+    stats.increment("queries_waiting_scheduling", numberQueriesPending);
+    if (numberQueriesPending === 0) return;
 
     const enabledClusters = await knex("cluster").where({
       status: CLUSTER_STATUS.ENABLED,
@@ -53,59 +57,79 @@ async function scheduleQueries() {
     });
 
     let currentClusterId = Math.floor(Math.random() * availableClusters.length);
-    for (const query of queriesToSchedule) {
-      const cluster = availableClusters[currentClusterId];
-      currentClusterId = (currentClusterId + 1) % availableClusters.length;
+    for (let idx = 0; idx <= MAX_QUERIES_QUEUED; idx++) {
+      try {
+        await knex.transaction(async (trx) => {
+          // Select a single query that needs to be scheduled with a row-level lock
+          // to prevent other schedulers on other instances from picking it up
+          const query = await knex("query")
+            .where({ status: QUERY_STATUS.AWAITING_SCHEDULING })
+            .transacting(trx)
+            .forUpdate()
+            .skipLocked()
+            .first();
 
-      const user = query.assumed_user || query.user;
-      const source = query.source || "trino-proxy";
-      const trinoHeaders = query.trino_request_headers || {};
+          // If no query could be found, early exit
+          if (!query) return;
 
-      // Pass through any user tags to Trino for resource group management
-      const clientTags = new Set(query.tags);
-      // Add custom tag so that queries can always be traced back to trino-proxy
-      clientTags.add("trino-proxy");
+          // Simple distribution of queries across all clusters
+          // TODO: Could improve this based on given weights or cluster size
+          const cluster = availableClusters[currentClusterId];
+          currentClusterId = (currentClusterId + 1) % availableClusters.length;
 
-      // Issue the statement request to the Trino cluster. This does not actually
-      // kick off execution of the query, the first nextUri call does.
-      const response = await axios({
-        url: `${cluster.url}/v1/statement`,
-        method: "post",
-        headers: {
-          // passthrough headers from client state
-          ...trinoHeaders,
-          // Overwrite the user, source, and tag headers with updated values
-          "X-Trino-User": user,
-          "X-Trino-Source": source,
-          "X-Trino-Client-Tags": Array.from(clientTags).join(","),
-        },
-        data: query.body,
-      });
+          const user = query.assumed_user || query.user;
+          const source = query.source || "trino-proxy";
+          const trinoHeaders = query.trino_request_headers || {};
 
-      await knex("query")
-        .where({ id: query.id })
-        .update({
-          cluster_query_id: response.data.id,
-          cluster_id: cluster.id,
-          status: response.data?.stats?.state || QUERY_STATUS.QUEUED,
-          next_uri: response.data.nextUri,
+          // Pass through any user tags to Trino for resource group management
+          const clientTags = new Set(query.tags);
+          // Add custom tag so that queries can always be traced back to trino-proxy
+          clientTags.add("trino-proxy");
+
+          // Issue the statement request to the Trino cluster. This does not actually
+          // kick off execution of the query, the first nextUri call does.
+          const response = await axios({
+            url: `${cluster.url}/v1/statement`,
+            method: "post",
+            headers: {
+              // passthrough headers from client state
+              ...trinoHeaders,
+              // Overwrite the user, source, and tag headers with updated values
+              "X-Trino-User": user,
+              "X-Trino-Source": source,
+              "X-Trino-Client-Tags": Array.from(clientTags).join(","),
+            },
+            data: query.body,
+          });
+
+          await knex("query")
+            .transacting(trx)
+            .where({ id: query.id })
+            .update({
+              cluster_query_id: response.data?.id,
+              cluster_id: cluster.id,
+              status: response.data?.stats?.state || QUERY_STATUS.QUEUED,
+              next_uri: response.data?.nextUri || null,
+            });
+
+          logger.info("Submitted query to Trino cluster", {
+            queryId: query.id,
+            cluster: cluster.name,
+            user,
+            source,
+            data: response.data,
+          });
+
+          stats.increment("query_queued", [
+            `cluster:${cluster.name}`,
+            `user:${user}`,
+            `source:${source}`,
+            ...clientTags,
+          ]);
         });
-
-      logger.info("Submitted query to Trino cluster", {
-        queryId: query.id,
-        cluster: cluster.name,
-        user,
-        source,
-        clientTags,
-        data: response.data,
-      });
-
-      stats.increment("query_queued", [
-        `cluster:${cluster.name}`,
-        `user:${user}`,
-        `source:${source}`,
-        ...clientTags,
-      ]);
+      } catch (scheduleErr) {
+        logger.error("Error scheduling query", scheduleErr);
+      }
     }
   } catch (err) {
     logger.error("Error scheduling queries", err);


### PR DESCRIPTION
This PR changes the behavior of the scheduler task to only query a single row at a time, with a row-level lock, from the `query` table.

This new pattern:
1. Gives users the ability to horizontally scale out containers without worrying about duplicate queries being scheduled. This supports #15.
2. Fixes an intermittent bug where two Trino statements might get the same `query` row id, causing those queries to get lost due to a mix-match of Trino ID + Trino keyId/num pairs