### PR TITLE
Allow api and scheduling to be run as separate services

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ yarn-error.log*
 
 # Miscellaneous
 .DS_Store
+
+# Docker volume
+postgres-data

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,6 @@ migrate:
 
 # Cleanup all docker containers
 clean:
-	docker-compose down
+	docker-compose down --rmi local --volumes --remove-orphans
 
 reset: clean migrate start

--- a/Makefile
+++ b/Makefile
@@ -13,13 +13,13 @@ format:
 
 # Start docker containers
 start:
-	docker-compose up --build --attach proxy
+	docker-compose up --build --attach api --attach scheduler
 
 # Run database migrations against db
 migrate:
 	docker-compose up -d postgres
-	docker-compose run --build proxy /app/node_modules/.bin/knex migrate:latest
-	docker-compose run --build proxy /app/node_modules/.bin/knex seed:run
+	docker-compose run --build api /app/node_modules/.bin/knex migrate:latest
+	docker-compose run --build api /app/node_modules/.bin/knex seed:run
 
 # Cleanup all docker containers
 clean:

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ make format
 
 ## Configuration
 
+- ENABLE_API: enables the Trino client API for accepting and checking queries (default: false)
+- ENABLE_SCHEDULER: enables the scheduler for sending queries to downstream clusters (default: false)
 - DB_URL: postgres database connection string
 - HTTP_ENABLED: whether HTTP server is enabled (set to true)
 - HTTP_LISTEN_PORT: HTTP port (default: 8080)

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,8 +1,10 @@
-version: "3.7"
+volumes:
+  postgres-data:
 
 services:
   proxy:
     build: .
+    container_name: proxy
     restart: always
     volumes:
       - ./migrations:/app/migrations
@@ -12,31 +14,44 @@ services:
       - 8080:8080
     depends_on:
       - postgres
-      - trino
+      - trino1
       - trino2
+      - trino3
     environment:
       - DB_URL=postgres://trino_proxy:trino_proxy@postgres/trino_proxy
       - HTTP_ENABLED=true
-      - LOG_LEVEL=info
+      - LOG_LEVEL=debug
       - NODE_ENV=production
       - ROUTING_METHOD=LOAD
 
   postgres:
     image: postgres:13
+    container_name: postgres
     restart: always
+    volumes:
+      - ./postgres-data:/var/lib/postgresql/data
     environment:
       POSTGRES_USER: trino_proxy
       POSTGRES_PASSWORD: trino_proxy
       POSTGRES_DB: trino_proxy
 
-  trino:
+  trino1:
     image: trinodb/trino
+    container_name: trino1
     restart: always
     ports:
-      - 8081:8080
+      - 8091:8080
 
   trino2:
     image: trinodb/trino
+    container_name: trino2
     restart: always
     ports:
-      - 8082:8080
+      - 8092:8080
+
+  trino3:
+    image: trinodb/trino
+    container_name: trino3
+    restart: always
+    ports:
+      - 8093:8080

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,9 +2,9 @@ volumes:
   postgres-data:
 
 services:
-  proxy:
+  api:
     build: .
-    container_name: proxy
+    container_name: api
     restart: always
     volumes:
       - ./migrations:/app/migrations
@@ -22,7 +22,28 @@ services:
       - HTTP_ENABLED=true
       - LOG_LEVEL=debug
       - NODE_ENV=production
-      - ROUTING_METHOD=LOAD
+      - ENABLE_API=true
+
+  scheduler:
+    build: .
+    container_name: scheduler
+    restart: always
+    volumes:
+      - ./src:/app/src
+    ports:
+      - 8081:8080
+    depends_on:
+      - postgres
+      - trino1
+      - trino2
+      - trino3
+    environment:
+      - DB_URL=postgres://trino_proxy:trino_proxy@postgres/trino_proxy
+      - HTTP_ENABLED=true
+      - LOG_LEVEL=debug
+      - NODE_ENV=production
+      - ROUTING_METHOD=ROUND_ROBIN
+      - ENABLE_SCHEDULER=true
 
   postgres:
     image: postgres:13

--- a/seeds/initialize.js
+++ b/seeds/initialize.js
@@ -73,8 +73,8 @@ exports.seed = async function (knex) {
   await knex("cluster").del();
   await knex("cluster").insert({
     id: uuidv4(),
-    name: "trino",
-    url: "http://trino:8080",
+    name: "trino1",
+    url: "http://trino1:8080",
     status: CLUSTER_STATUS.ENABLED,
     tags: ["blue"],
     updated_at: now,
@@ -85,7 +85,7 @@ exports.seed = async function (knex) {
     name: "trino2",
     url: "http://trino2:8080",
     status: CLUSTER_STATUS.ENABLED,
-    tags: ["blue", "green"],
+    tags: ["green"],
     updated_at: now,
     created_at: now,
   });
@@ -94,7 +94,7 @@ exports.seed = async function (knex) {
     name: "trino3",
     url: "http://trino3:8080",
     status: CLUSTER_STATUS.ENABLED,
-    tags: ["green"],
+    tags: [],
     updated_at: now,
     created_at: now,
   });

--- a/src/lib/trino.js
+++ b/src/lib/trino.js
@@ -21,7 +21,7 @@ const CLUSTER_STATUS = {
 };
 
 let schedulerRunning = false;
-const SCHEDULER_DELAY_MS = 1000 * 15;
+const SCHEDULER_DELAY_MS = parseInt(process.env.SCHEDULER_DELAY_MS) || 1000 * 5;
 const MAX_QUERIES_QUEUED = 10;
 
 const clusterHeaderRegex = new RegExp("-- Cluster: *(.*)");
@@ -294,10 +294,14 @@ async function runSchedulerAndReschedule() {
   setTimeout(runSchedulerAndReschedule, SCHEDULER_DELAY_MS);
 }
 
-logger.info(`Scheduling query scheduler to run every ${SCHEDULER_DELAY_MS}ms`);
-setTimeout(runSchedulerAndReschedule, SCHEDULER_DELAY_MS);
+async function startScheduler() {
+  logger.info(
+    `Scheduling query scheduler to run every ${SCHEDULER_DELAY_MS}ms`
+  );
+  setTimeout(runSchedulerAndReschedule, SCHEDULER_DELAY_MS);
+}
 
 module.exports = {
-  scheduleQueries,
+  startScheduler,
   CLUSTER_STATUS,
 };


### PR DESCRIPTION
The PR adds environment variable toggles for enabling the API and Scheduler components separately. This allows users to have separate microservices for the two features so that they can be scaled independently.