### PR TITLE
Block submission of empty queries

### DIFF
--- a/src/routes/trino.js
+++ b/src/routes/trino.js
@@ -44,6 +44,11 @@ router.post("/v1/statement", async (req, res) => {
     return res.status(401).json({ error: "Unauthorized" });
   }
 
+  // Block submission of empty queries since Trino won't accept them
+  if (!req.body) {
+    return res.status(400).json({ error: "Query is required" });
+  }
+
   // Default user to whoever submitted the query
   let assumedUser = req.user.username;
   // Initialize empty client tags using a set to prevent duplicates


### PR DESCRIPTION
This PR returns a 400 status code on the `/v1/statement` route if a query is empty. Trino does not accept empty queries, so the proxy service should not either.