### PR TITLE
Separate out user and trace caches

### DIFF
--- a/src/lib/memcache.js
+++ b/src/lib/memcache.js
@@ -1,9 +1,38 @@
 const { LRUCache } = require("lru-cache");
 
-const maxCacheSize = process.env.TRACE_CACHE_SIZE
-  ? parseInt(process.env.TRACE_CACHE_SIZE)
-  : 1000;
-
-module.exports = new LRUCache({
-  max: maxCacheSize,
+/**
+ * This cache stores mappings of `x-trino-trace-token` headers
+ * to the assumed user of the initial query. This is used for
+ * clients that authenticate on the initial request using headers
+ * and pass the trace token for future requests.
+ *
+ * There is no TTL on this cache as some queries are long-running
+ * and we need to keep the mapping around for a while.
+ */
+const traceCache = new LRUCache({
+  max: process.env.TRACE_CACHE_SIZE
+    ? parseInt(process.env.TRACE_CACHE_SIZE)
+    : 1000,
 });
+
+/**
+ * This cache stores the `user` data from Postgres by ID, allowing
+ * for quicker user lookup when determining which cluster to
+ * route a query to.
+ *
+ * There is a short TTL on this cache to ensure that updates to the
+ * user's cluster tags are fetched quickly by the service.
+ */
+const userCache = new LRUCache({
+  max: process.env.USER_CACHE_SIZE
+    ? parseInt(process.env.USER_CACHE_SIZE)
+    : 1000,
+  ttl: process.env.USER_CACHE_TTL_MS
+    ? parseInt(process.env.USER_CACHE_TTL_MS)
+    : 1000 * 60 * 3, // 3min
+});
+
+module.exports = {
+  traceCache,
+  userCache,
+};

--- a/src/lib/query.js
+++ b/src/lib/query.js
@@ -1,5 +1,5 @@
 const { knex } = require("./knex");
-const cache = require("./memcache");
+const { traceCache } = require("./memcache");
 const logger = require("./logger");
 const stats = require("./stats");
 
@@ -38,7 +38,7 @@ async function getQueryHeaderInfo(traceId) {
     return null;
   }
 
-  const cachedHeaderData = cache.get(traceId);
+  const cachedHeaderData = traceCache.get(traceId);
   if (cachedHeaderData) {
     return cachedHeaderData;
   }

--- a/src/lib/trino.js
+++ b/src/lib/trino.js
@@ -8,7 +8,7 @@ const { QUERY_STATUS } = require("../lib/query");
 const { createErrorResponseBody } = require("../lib/helpers");
 const uuidv4 = require("uuid").v4;
 const TEMP_HOST = "http://localhost:5110"; // temp host later override to external host
-const cache = require("../lib/memcache");
+const { userCache } = require("../lib/memcache");
 
 const ROUTING_METHOD = process.env.ROUTING_METHOD || "ROUND_ROBIN";
 const DEFAULT_CLUSTER_TAG = process.env.DEFAULT_CLUSTER_TAG
@@ -219,15 +219,11 @@ async function scheduleQueries() {
 }
 
 async function getCluster(availableClusters, currentClusterId, query) {
-  logger.debug("Routing Method: " + ROUTING_METHOD);
-
-  // get user's cluster tags and default to DEFAULT_CLUSTER_TAG if no tags provided
-
-  let queryUser = cache.get(query.user);
-
+  // Get user's cluster tags and default to DEFAULT_CLUSTER_TAG if no tags provided
+  let queryUser = userCache.get(query.user);
   if (!queryUser) {
     queryUser = await knex("user").where({ id: query.user }).first();
-    cache.set(query.user, queryUser);
+    userCache.set(query.user, queryUser);
   }
 
   const userClusterTags = queryUser.options?.clusterTags || DEFAULT_CLUSTER_TAG;

--- a/src/routes/trino.js
+++ b/src/routes/trino.js
@@ -10,7 +10,7 @@ const {
 } = require("../lib/helpers");
 const { knex } = require("../lib/knex");
 const logger = require("../lib/logger");
-const cache = require("../lib/memcache");
+const { traceCache } = require("../lib/memcache");
 const {
   getQueryById,
   getQueryHeaderInfo,
@@ -71,7 +71,7 @@ router.post("/v1/statement", async (req, res) => {
       if (!info) {
         info = parseFirstQueryHeader(req.body, req.user.parsers);
         logger.debug("Parsed header info from query", info);
-        cache.set(trinoTraceToken, info);
+        traceCache.set(trinoTraceToken, info);
       }
 
       assumedUser = info.user;


### PR DESCRIPTION
This PR separates out the in-memory caches for users and traces. The `user` cache should have a TTL on it, which would allow us to make changes to user routing dynamically, while the `trace` cache can hold onto trace ID matches for longer running queries.