### PR TITLE
Adding Trino Config Files for Local Testing

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -62,6 +62,8 @@ services:
     restart: always
     volumes:
       - ./seeds/trino_config:/etc/trino
+    depends_on:
+      - postgres
     ports:
       - 8091:8080
 
@@ -71,6 +73,8 @@ services:
     restart: always
     volumes:
       - ./seeds/trino_config:/etc/trino
+    depends_on:
+      - postgres
     ports:
       - 8092:8080
 
@@ -80,5 +84,7 @@ services:
     restart: always
     volumes:
       - ./seeds/trino_config:/etc/trino
+    depends_on:
+      - postgres
     ports:
       - 8093:8080

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -42,7 +42,7 @@ services:
       - HTTP_ENABLED=true
       - LOG_LEVEL=debug
       - NODE_ENV=production
-      - ROUTING_METHOD=ROUND_ROBIN
+      - ROUTING_METHOD=LOAD
       - ENABLE_SCHEDULER=true
 
   postgres:
@@ -60,6 +60,8 @@ services:
     image: trinodb/trino
     container_name: trino1
     restart: always
+    volumes:
+      - ./seeds/trino_config:/etc/trino
     ports:
       - 8091:8080
 
@@ -67,6 +69,8 @@ services:
     image: trinodb/trino
     container_name: trino2
     restart: always
+    volumes:
+      - ./seeds/trino_config:/etc/trino
     ports:
       - 8092:8080
 
@@ -74,5 +78,7 @@ services:
     image: trinodb/trino
     container_name: trino3
     restart: always
+    volumes:
+      - ./seeds/trino_config:/etc/trino
     ports:
       - 8093:8080

--- a/seeds/trino_config/catalog/jmx.properties
+++ b/seeds/trino_config/catalog/jmx.properties
@@ -1,1 +1,0 @@
-connector.name=jmx

--- a/seeds/trino_config/catalog/jmx.properties
+++ b/seeds/trino_config/catalog/jmx.properties
@@ -1,0 +1,1 @@
+connector.name=jmx

--- a/seeds/trino_config/catalog/memory.properties
+++ b/seeds/trino_config/catalog/memory.properties
@@ -1,0 +1,1 @@
+connector.name=memory

--- a/seeds/trino_config/catalog/proxy.properties
+++ b/seeds/trino_config/catalog/proxy.properties
@@ -1,0 +1,4 @@
+connector.name=postgresql
+connection-url=jdbc:postgresql://postgres:5432/trino_proxy
+connection-user=trino_proxy
+connection-password=trino_proxy

--- a/seeds/trino_config/catalog/tpcds.properties
+++ b/seeds/trino_config/catalog/tpcds.properties
@@ -1,0 +1,2 @@
+connector.name=tpcds
+tpcds.splits-per-node=4

--- a/seeds/trino_config/catalog/tpch.properties
+++ b/seeds/trino_config/catalog/tpch.properties
@@ -1,0 +1,2 @@
+connector.name=tpch
+tpch.splits-per-node=4

--- a/seeds/trino_config/config.properties
+++ b/seeds/trino_config/config.properties
@@ -1,0 +1,10 @@
+#single node install config
+coordinator=true
+node-scheduler.include-coordinator=true
+http-server.http.port=8080
+discovery.uri=http://localhost:8080
+catalog.management=${ENV:CATALOG_MANAGEMENT}
+
+#Forcing Web UI Auth to fixed to support query router
+web-ui.authentication.type=fixed
+web-ui.user=admin

--- a/seeds/trino_config/jvm.config
+++ b/seeds/trino_config/jvm.config
@@ -1,0 +1,19 @@
+-server
+-agentpath:/usr/lib/trino/bin/libjvmkill.so
+-XX:InitialRAMPercentage=80
+-XX:MaxRAMPercentage=80
+-XX:G1HeapRegionSize=32M
+-XX:+ExplicitGCInvokesConcurrent
+-XX:+HeapDumpOnOutOfMemoryError
+-XX:+ExitOnOutOfMemoryError
+-XX:-OmitStackTraceInFastThrow
+-XX:ReservedCodeCacheSize=256M
+-XX:PerMethodRecompilationCutoff=10000
+-XX:PerBytecodeRecompilationCutoff=10000
+-Djdk.attach.allowAttachSelf=true
+-Djdk.nio.maxCachedBufferSize=2000000
+# Reduce starvation of threads by GClocker, recommend to set about the number of cpu cores (JDK-8192647)
+-XX:+UnlockDiagnosticVMOptions
+-XX:GCLockerRetryAllocationCount=32
+# Allow loading dynamic agent used by JOL
+-XX:+EnableDynamicAgentLoading

--- a/seeds/trino_config/log.properties
+++ b/seeds/trino_config/log.properties
@@ -1,0 +1,2 @@
+# Enable verbose logging from Trino
+#io.trino=DEBUG

--- a/seeds/trino_config/node.properties
+++ b/seeds/trino_config/node.properties
@@ -1,0 +1,2 @@
+node.environment=docker
+node.data-dir=/data/trino


### PR DESCRIPTION
This PR adds in configuration files for trino to allow for custom settings. This is necessary to set the web-ui authentication type to "fixed", which is currently necessary to test LOAD based routing locally. These files can also be adjusted as needed if you want to test additional Trino configurations. 

With the exception of the web-ui authentication setting and adding an additional config to connect to the proxy DB, these files were copied from the current latest trino docker image with not other modifications.

PR should be low risk, as there is no actual functionality change to the proxy itself. 