### PR TITLE
chooseCluster(): check tags only if present

### DIFF
--- a/src/lib/trino.ts
+++ b/src/lib/trino.ts
@@ -330,13 +330,23 @@ async function chooseCluster(
 
     // Clusters with tags are reserved for queries/users that target them
     if (clusterTags.length) {
+      // If either the query or the user has tags, they must match with those of
+      // the cluster; an absence of tags on the query or on the user may match
+      // with any cluster, even if the cluster has tags.
+
       // Skip if query-specified tags and there's no overlap with cluster
-      if (!_.intersection(queryClusterTags, clusterTags).length) {
+      if (
+        queryClusterTags.length > 0 &&
+        !_.intersection(queryClusterTags, clusterTags).length
+      ) {
         return false;
       }
 
       // Skip if user-specified tags and there's no overlap with cluster
-      if (!_.intersection(userClusterTags, clusterTags).length) {
+      if (
+        userClusterTags.length > 0 &&
+        !_.intersection(userClusterTags, clusterTags).length
+      ) {
         return false;
       }
     }


### PR DESCRIPTION
Prior to #39, when choosing onto which cluster to schedule a new query, `queryClusterTags` was checked against the Cluster's tags only if the `clusterHeaderRegex` pattern (`/-- Cluster: *(.*)/`) matched the `query.body`.

This doesn't really work if most `query.body` payloads don't contain a tag but all `availableClusters` do: change this behavior to only enforce tags if they are present. In contrast to #40, this makes it so the `userClusterTags` are still checked and enforced, such that a user cannot gain access to a cluster they would not normally have access to with a leading `-- Cluster: XXX` comment.